### PR TITLE
Added automated kill script & updated readme

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 #
 # Linux start script should use lf
 /gradlew        text eol=lf
+*.sh            text eol=lf
 
 # These are Windows script files and should use crlf
 *.bat           text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ build
 main/webserver/node_modules
 ### Others ###
 log.txt
+process_ids.txt
 
 

--- a/README.md
+++ b/README.md
@@ -2,25 +2,39 @@
 
 A multiplayer snake game built as a web engineering project.
 
-## How to run the game
-
-**Dependency:** A local Java install with set PATH variable. 
-
-The game can be run locally by starting the server via the command `./gradlew runServer` and then accessing it at `http://localhost:5000/` in your web browser.
-
 ## Gameplay
 
-In Snake Royale, up to 9 players play in a lobby, with the goal of becoming the last snake standing. Every 30 seconds, the player with the smallest snake loses one heart. The gameplay otherwise follows the traditional rules of snake.
+The main difference between the traditional Snake and Snake Royale is that, it is played in lobbies ranging from 
+2 to 9 players where apples are shared between all lobby members, meaning that only one player can eat an apple.
 
-## Contributions
+Every 30 seconds, the shortest player loses one life. Additionally, the length of all other players' snakes is reduced by the length of the shortest player to keep the gameplay dynamic.
 
-Feel free to contribute to the project by submitting pull requests or reporting any issues you may encounter. We welcome all contributions and are excited to see what the community can come up with to improve the game.
+In the sense of a battle roayale game its the players main goal to be the last snake standing, which requires
+smart path choices, good reflexes and a bit of luck. 
 
-## Disclaimer
-This project is for educational purposes only, it is not intended for any commercial use.
+If two players are tied for the shortest snake or eat an apple at the same time, the effects are applied to both players.
 
-## Enjoy playing Snake Royale!
+## Getting Started
 
----
+### Dependencies
 
-This README was created by an AI model called ChatGPT, the project owners do not claim ownership of this document.
+- Java (with the path variable set)
+- A low latency internet connection (preferably wired)
+
+### Installation
+
+1. Clone the repository and navigate to the root folder
+2. Run the gradle commands `gradlew runServer` to build and run the project
+3. Open a web browser and navigate to `http://localhost:5000` to play the game
+
+In case you want to build / run the components separately:
+- `gradlew build` builds the entire project
+- `gradlew runWebsocket` starts the websocket (gameserver)
+- `gradlew runWebserver` starts the webserver 
+
+### Stopping the game
+
++ On **Windows** it should be as simple as closing the command prompt. 
++ On **Mac** and **Linux** you may have to execute `./kill.sh` from project root to kill the websocket and webserver processes.
+
+## Enjoy the game!

--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ In case you want to build / run the components separately:
 ### Stopping the game
 
 + On **Windows** it should be as simple as closing the command prompt. 
-+ On **Mac** and **Linux** you may have to execute `./kill.sh` from project root to kill the websocket and webserver processes.
++ On **Mac** and **Linux** you have to execute the provided kill-script via `./kill.sh` from project root to stop the websocket and webserver processes.
 
 ## Enjoy the game!

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins{
 }
 
 
-
 /* Project Structure */
 def srcDir = 'main'
 def srcJava = "${srcDir}/gameserver/src"
@@ -19,7 +18,7 @@ def javaServer = "GameServer"
 def javascriptServerPath = "${srcWebserver}/server.js"
 
 /* Gradles output - should not be uploaded to git, but may for live demo, so its flawless*/
-project.buildDir = '/generated'
+project.buildDir = './generated'
 
 
 /*The Java Source Directories*/
@@ -49,6 +48,7 @@ node{
     nodeProjectDir = file("${project.projectDir}/${srcJavascript}")
 }
 
+
 /* NOT PARALLELIZABLE */
 /* Runs the Game Server */
 task runWebsocket(type:JavaExec)  {
@@ -77,4 +77,13 @@ task runServer(type:Exec) {
     }
 }
 
+/* todo in case we want to have this for windows too
+task kill(type:Exec){
+	if(os.isLinux() || os.isMacOsX()) {
+		commandLine = ['./kill.sh']
+	}
+}
+ */
+
 runServer.dependsOn(["build", "npmInstall"])
+build.dependsOn(["npmInstall"])

--- a/kill.sh
+++ b/kill.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# read the process IDs from the file
+while read pid; do
+  # check if the process is still running
+  if kill -0 $pid 2>/dev/null; then
+    # if it is, send the kill signal
+    echo "Killing process $pid"
+    kill $pid
+  else
+    echo "Process $pid is not running"
+  fi
+done < process_ids.txt
+# delete the files contents
+> process_ids.txt

--- a/main/gameserver/src/Game.java
+++ b/main/gameserver/src/Game.java
@@ -140,7 +140,7 @@ public class Game {
         }
 
         // update the scores and end the game if its over
-        if(deadSnakes == participants.size()) { //todo add -1  if we want to notify once one man standing
+        if(deadSnakes == participants.size() - 1) { //todo add -1  if we want to notify once one man standing
             this.state = State.STOPPED;
             sendScores();
         }

--- a/main/gameserver/src/GameServer.java
+++ b/main/gameserver/src/GameServer.java
@@ -165,7 +165,7 @@ public class GameServer {
      * @return always empty optional
      */
     public Optional<WSMessage> handlePlayerMove(WSMessage message){
-        System.out.println(message.getOpcode() + " sent ");
+        //System.out.println(message.getOpcode() + " sent ");
         Player player = players.get(message.getSender());
         player.snake.changeDirection(message.getOpcode()); //gameData should not be null
         return Optional.empty();

--- a/main/gameserver/src/GameServer.java
+++ b/main/gameserver/src/GameServer.java
@@ -230,18 +230,27 @@ public class GameServer {
         Player caller = players.get(message.getSender());
         Lobby lobby = lobbies.get(caller.subscribedToLobbyId);
 
-        lobby.prepareGame();
         if (lobby.owner.equals(caller)) {
             // sends game go and the time interval for player deaths
-            String startMessage = new WSMessage(OpCode.START_GAME_RESPONSE).jsonify();
-            for (Player p : lobby.members.values()) {
-                if (p.connection.isOpen()) {
-                    p.connection.send(startMessage);
+            if (lobby.members.size() >= Lobby.MIN_LOBBY_SIZE) {
+                lobby.prepareGame();
+                String startMessage = new WSMessage(OpCode.START_GAME_RESPONSE).jsonify();
+                for (Player p : lobby.members.values()) {
+                    if (p.connection.isOpen()) {
+                        p.connection.send(startMessage);
+                    }
+                }
+                new Thread(lobby.game.RunGame).start();
+            } else {
+                // notify the owner that he can not start the lobby because there are not enough players
+                if (lobby.owner.connection.isOpen()) {
+                    String notEnoughPlayersMessage = new WSMessage(OpCode.NOT_ENOUGH_PLAYERS).jsonify();
+                    lobby.owner.connection.send(notEnoughPlayersMessage);
                 }
             }
-            new Thread(lobby.game.RunGame).start();
 
         }
+        // caller was not owner - he can not start the game
         return Optional.empty();
     }
 

--- a/main/gameserver/src/Lobby.java
+++ b/main/gameserver/src/Lobby.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Lobby {
 
     public static final int MAX_LOBBY_SIZE = 9;
-    public static final int MIN_LOBBY_SIZE = 4;
+    public static final int MIN_LOBBY_SIZE = 2;
 
     @Expose
     public final String ID;

--- a/main/gameserver/src/OpCode.java
+++ b/main/gameserver/src/OpCode.java
@@ -13,6 +13,7 @@ enum OpCode implements WSServer.OpCode {
     CREATE_LOBBY_RESPONSE, // sends a lobby
     START_GAME, // nothing
     START_GAME_RESPONSE, // nothing
+    NOT_ENOUGH_PLAYERS, // nothing
     JOIN_LOBBY, // expects a string
     JOIN_LOBBY_RESPONSE, // sends a lobby
     JOIN_LOBBY_FAILED, // nothing

--- a/runServer.sh
+++ b/runServer.sh
@@ -6,3 +6,7 @@ javascriptServerPath=$3
 
 ( java -cp "$javaClasspath" $javaMainClass ) &
 ( node  $javascriptServerPath )  &
+
+sleep 3
+echo $(pgrep -f "java -cp $javaClasspath $javaMainClass") > process_ids.txt
+echo $(pgrep -f "node $javascriptServerPath") >> process_ids.txt


### PR DESCRIPTION
A kill script for mac os and linux was added for convenience. 
Induces risk: If not used to shutdown the processes old pids will reside inside it. If the script is called after reboot for whatever reason before the project was run again, this may lead to kill of unrelated processes.
We may add a call to this script inside the runServer.sh as well - this will allow successive rebuilds without having to use the kill script between builds. 